### PR TITLE
Amend text after "static" to include additional spacing

### DIFF
--- a/Language-Reference-VBA/articles/bd870302-7f40-7476-f1df-ce2bc3e4d567.md
+++ b/Language-Reference-VBA/articles/bd870302-7f40-7476-f1df-ce2bc3e4d567.md
@@ -5,7 +5,7 @@ Some commands and actions cause Visual Basic to stop analyzing code. This error 
 
 
 
-- Some edits, like declaring a  **Static** [variable](b8bdf64f-5920-1ae9-16d0-b26d09524a30.md), and some commands, like those for adding a new  [module](b8bdf64f-5920-1ae9-16d0-b26d09524a30.md) or form, cause running or suspended code to stop.
+- Some edits, like declaring a  **Static**  [variable](b8bdf64f-5920-1ae9-16d0-b26d09524a30.md), and some commands, like those for adding a new  [module](b8bdf64f-5920-1ae9-16d0-b26d09524a30.md) or form, cause running or suspended code to stop.
     
     If you don't want to stop running code, don't add or execute the command.
     


### PR DESCRIPTION
This additional space is also between "new" and "module" and here lies between "static" and "variable". I suspect there may be an issue in the MS VBA Documentation parser that isn't including that extra space, but I'm not sure where to look for it.