### PR TITLE
Update 74629499-04d1-11d5-20b8-02b72bb110ee.md

### DIFF
--- a/Excel-VBA/articles/74629499-04d1-11d5-20b8-02b72bb110ee.md
+++ b/Excel-VBA/articles/74629499-04d1-11d5-20b8-02b72bb110ee.md
@@ -6,7 +6,7 @@ Creates an object that represents an item in a document saved to a Web page. Suc
 
 ## Syntax
 
- _expression_. **Add**( **_SourceType_**,  **_FileName_**,  **_Sheet_**,  **_Source_**,  **_HtmlType_**,  **_DivID_**,  **_Title_**)
+ _expression_. **Add**( **_SourceType_**,  **_Filename_**,  **_Sheet_**,  **_Source_**,  **_HtmlType_**,  **_DivID_**,  **_Title_**)
 
  _expression_A variable that represents a  **PublishObjects** object.
 
@@ -18,7 +18,7 @@ Creates an object that represents an item in a document saved to a Web page. Suc
 |**Name**|**Required/Optional**|**Data Type**|**Description**|
 |:-----|:-----|:-----|:-----|
 |SourceType|Required| ** [XlSourceType](d2effec0-3c7b-4347-99c0-0044c7471555.md)**|The source type.|
-|Title|Optional| **Variant**| **String**. The URL (on the intranet or the Web) or path (local or network) to which the source object was saved.|
+|Filename|Optional| **Variant**| **String**. The URL (on the intranet or the Web) or path (local or network) to which the source object was saved.|
 |Sheet|Optional| **Variant**|The name of the worksheet that was saved as a Web page.|
 |Source|Optional| **Variant**|A unique name used to identify items that have one of the following constants as their SourceType argument: **xlSourceAutoFilter**,  **xlSourceChart**,  **xlSourcePivotTable**,  **xlSourcePrintArea**,  **xlSourceQuery**, or  **xlSourceRange**. If SourceType is **xlSourceRange**,  **Source** specifies a range, which can be a defined name. IfSourceType is **xlSourceChart**,  **xlSourcePivotTable**, or  **xlSourceQuery**, Source specifies the name of a chart, PivotTable report, or query table.|
 |HtmlType|Optional| **Variant**|Specifies whether the item is saved as an interactive Microsoft Office Web component or as static text and images. Can be one of the  ** [XlHTMLType](1eb7246a-ca31-f468-0a75-363af7100e98.md)** constants: **xlHtmlCalc**,  **xlHtmlChart**,  **xlHtmlList**, or  **xlHtmlStatic**.|


### PR DESCRIPTION
Parameters table had two parameters named "Title". Amended the first of these to the correct parameter name - Filename. Also, in the Syntax section, changed the parameter name from FileName to Filename as this is what is shown in the VBA editor and for consistency with the Parameters table and Example code