### PR TITLE
Update 8b716453-7656-e8b8-f6b0-0dc97ef2714d.md

### DIFF
--- a/Word-VBA/articles/8b716453-7656-e8b8-f6b0-0dc97ef2714d.md
+++ b/Word-VBA/articles/8b716453-7656-e8b8-f6b0-0dc97ef2714d.md
@@ -17,7 +17,7 @@ Expands the specified range or selection. Returns the number of characters added
 
 |**Name**|**Required/Optional**|**Data Type**|**Description**|
 |:-----|:-----|:-----|:-----|
-|Unit|Optional| **Variant**|A  **WdUnits** constant that represents the unit by which to expand the range. The default value is **wdWord**.|
+|Unit|Optional| **Variant**|A  **[WdUnits](d8726033-e492-0d2d-bea1-3713e84d5701.md)** constant that represents the unit by which to expand the range. The default value is **wdWord**.|
 
 ## Example
 


### PR DESCRIPTION
At least the first reference on a page to a class or object should include a link to the documentation for the referred object