### PR TITLE
Update 27047561-9d76-b37d-100d-1c58e6edf494.md

### DIFF
--- a/Excel-VBA/articles/27047561-9d76-b37d-100d-1c58e6edf494.md
+++ b/Excel-VBA/articles/27047561-9d76-b37d-100d-1c58e6edf494.md
@@ -21,7 +21,7 @@ Marks a user-defined function as volatile. A volatile function must be recalcula
 
 ## Example
 
-This example marks the user-defined function "My_Func" as volatile. The function will be recalculated whenever calculation occurs in any cells on the worksheet on which this function appears.
+This example marks the user-defined function "My_Func" as volatile. The function will be recalculated whenever any cell in any workbook in the application window changes value. Recalculation of the function is not restricted to changes or calculation cycles on the worksheet on which this function appears and should be used judiciously or calculation lag can become a problem.
 
 
 ```


### PR DESCRIPTION
The statement that a user defined function marked volatile is only 'recalculated whenever calculation occurs in any cells on the worksheet on which this function appears' was just plain wrong. In fact, it will not only recalculate whenever any value in the workbook is changed (calculation cycle or no calculation cycle) but in the case of multiple workbooks open within a single application instance, it will recalculate when values change on other workbooks open within the same application instance.