### PR TITLE
Update a0c8bafb-294c-32ff-0591-1a798aebb4b4.md

### DIFF
--- a/Excel-VBA/articles/a0c8bafb-294c-32ff-0591-1a798aebb4b4.md
+++ b/Excel-VBA/articles/a0c8bafb-294c-32ff-0591-1a798aebb4b4.md
@@ -8,12 +8,10 @@ Returns or sets the array formula of a range. Returns (or can be set to) a singl
 
  _expression_. **FormulaArray**
 
- _expression_A variable that represents a  **Range** object.
+ _expression_. A variable that represents a  **Range** object.
 
 
 ## Remarks
-
-If you use this property to enter an array formula, the formula must use the R1C1 reference style, not the A1 reference style (see the second example). 
 
 The  **FormulaArray** property also has a character limit of 255.
 
@@ -27,14 +25,14 @@ This example enters the number 3 as an array constant in cells A1:C5 on Sheet1.
 Worksheets("Sheet1").Range("A1:C5").FormulaArray = "=3"
 ```
 
-This example enters the array formula =SUM(R1C1:R3C3) in cells E1:E3 on Sheet1.
+This example enters the array formula =SUM(A1:C3) in cells E1:E3 on Sheet1.
 
 
 
 
 ```
 Worksheets("Sheet1").Range("E1:E3").FormulaArray = _ 
- "=Sum(R1C1:R3C3)"
+ "=Sum(A1:C3)"
 ```
 
 


### PR DESCRIPTION
The ArrayFormula property does not require, and in fact does not retain, R1C1 references. Documentation updated.