### PR TITLE
Correct Example

### DIFF
--- a/Word-VBA/articles/f1340e1e-6aec-edaa-78c2-47e3e1d5299f.md
+++ b/Word-VBA/articles/f1340e1e-6aec-edaa-78c2-47e3e1d5299f.md
@@ -29,7 +29,8 @@ This example maximizes any document window when it is activated. This code must 
 Public WithEvents appWord as Word.Application 
  
 Private Sub appWord_WindowActivate _ 
- (ByVal Wn As Word.Window) 
+ (ByVal Doc As Word.Document, _
+  ByVal Wn As Word.Window) 
  Wn.WindowState = wdWindowStateMaximize 
 End Sub
 ```


### PR DESCRIPTION
Example was missing required argument