### PR TITLE
Update d26e6786-064a-174c-5b9f-79e85b34f59b.md

### DIFF
--- a/Excel-VBA/articles/d26e6786-064a-174c-5b9f-79e85b34f59b.md
+++ b/Excel-VBA/articles/d26e6786-064a-174c-5b9f-79e85b34f59b.md
@@ -30,7 +30,7 @@ PivotCache
 
 The following two  **xlPivotTableSourceType** constants are not supported when creating a PivotCache using this method: **xlPivotTable** and **xlScenario** . A run-time error is returned if one of these two constants is supplied.
 
-The  _SourceData_ argument is required if _SourceType_ isn't **xlExternal** . It can be a **Range** object (when _SourceType_ is either **xlConsolidation** or **xlDatabase** ) or an Excel Workbook Connection object (when _SourceType_ is **xlExternal** ).
+The  _SourceData_ argument is required if _SourceType_ isn't **xlExternal** . It should be passed a Range (when _SourceType_ is either **xlConsolidation** or **xlDatabase** ) or an Excel Workbook Connection object (when _SourceType_ is **xlExternal** ). When passing a Range, it is recommended to either use a string to specify the workbook, worksheet, and cell range, or set up a named range and pass the name as a string. Passing a **Range** object may cause "type mismatch" errors unexpectedly.
 
 When not supplied, the version of the PivotTable will be  **xlPivotTableVersion12** . The use of the **xlPivotTableVersionCurrent** constant is not allowed and returns a run-time error if it is supplied.
 


### PR DESCRIPTION
Passing a Range object as SourceData seems to be a known issue or several years that has not been fixed even in Office 2013. 

There are several stack overflow discussions where people who have passed Range objects to PivotCache.Create get a "type mismatch" error unexpectedly, even after the code ran successfully in previous testing. I encountered this where workbooks I had created with a Range object worked fine for weeks of testing, and then failed with "type mismatch" sporadically after the workbooks were put into circulation. Using a string as a workbook/cell range reference or a named range as a reference appeared to fix the problem. The official documentation should be updated, because passing a Range object here is unstable, yet the documentation specifies that is what should be passed.