### PR TITLE
Not working as expected

### DIFF
--- a/Excel-VBA/articles/a36c5080-1d7e-a941-1bad-94f92522c7cf.md
+++ b/Excel-VBA/articles/a36c5080-1d7e-a941-1bad-94f92522c7cf.md
@@ -1,7 +1,13 @@
 
 # Application.OperatingSystem Property (Excel)
 
-Returns the name and version number of the current operating system — for example, "Windows (32-bit) 4.00" or "Macintosh 7.00". Read-only  **String** .
+Returns the name and version number of the current operating system — for example, "Windows (32-bit) 4.00" or "Macintosh 7.00".
+
+Return e.g. "Windows (32-bit) NT 6.02" with Win8.1 (=6.02, **64bit**) and Excel 2013 (15.0.4631.1000, 32bit)
+
+E.g. "Windows (64-bit) NT :.00" with Win10 (64bit) and Excel 2016 (16.0.6326.1010, 64bit)
+
+Read-only  **String** .
 
 
 ## Syntax

--- a/Excel-VBA/articles/a36c5080-1d7e-a941-1bad-94f92522c7cf.md
+++ b/Excel-VBA/articles/a36c5080-1d7e-a941-1bad-94f92522c7cf.md
@@ -17,9 +17,8 @@ This example displays the name of the operating system.
 
 
 ```
-MsgBox "Microsoft Excel is using " &amp; Application.OperatingSystem
+MsgBox "Microsoft Excel is using " & Application.OperatingSystem
 ```
-
 
 ## See also
 


### PR DESCRIPTION
With Win8.1 (=6.02, 64bit) and Excel 2013 (15.0.4631.1000, 32bit) the Application.OperatingSystem gives "Windows (32-bit) NT 6.02" ! 
The 32bit seems to be the bit-size of the application Excel, independent from the operating system!

With Win10 (64bit) and Excel 2016 (16.0.6326.1010, 64bit)  Application.OperatingSystem gives "Windows (64-bit) NT :.00" !
The Version number formatting seems to have a problem!