### PR TITLE
Variable name in the example corrected

### DIFF
--- a/Access-VBA/articles/d62150d2-6dc6-85c0-0452-e9e5fee199b4.md
+++ b/Access-VBA/articles/d62150d2-6dc6-85c0-0452-e9e5fee199b4.md
@@ -29,7 +29,7 @@ Private Sub btnUndo_Click()
  
  For Each ctlTextbox in Me.Controls 
  If ctlTextbox.ControlType = acTextBox Then 
- ctlTextbox.Value = ctl.OldValue 
+ ctlTextbox.Value = ctlTextbox.OldValue 
  End If 
  Next ctlTextbox 
  


### PR DESCRIPTION
Part of the variable name was missing in one place in the first example.