### PR TITLE
Say you can index as .ListTemplates("Name")

### DIFF
--- a/Word-VBA/articles/cb5ad343-fbcc-22f0-6a05-83f1480da691.md
+++ b/Word-VBA/articles/cb5ad343-fbcc-22f0-6a05-83f1480da691.md
@@ -18,7 +18,7 @@ Returns a  **ListTemplate** object that represents a new list template.
 |**Name**|**Required/Optional**|**Data Type**|**Description**|
 |:-----|:-----|:-----|:-----|
 | _OutlineNumbered_|Optional| **Variant**| **True** to apply outline numbering to the new list template.|
-| _Name_|Optional| **Variant**|An optional name used for linking the list template to a LISTNUM field. You cannot use this name to index the list template in the collection.|
+| _Name_|Optional| **Variant**|An optional name used for linking the list template to a LISTNUM field. You can use this name to index the list template in the collection.|
 
 ### Return Value
 


### PR DESCRIPTION
"Cannot" contradicts [ListTemplates.Item Method (Word)](VBA-content/Word-VBA/articles/fb33549f-3ca6-d969-e866-c57ebaa85dc6.md), which says that the index "Can be . . . the name of the individual object." 
 
To confirm, I ran the following code without errors. 
```vba
Set objA = ActiveDocument.ListTemplates.Add(OutlineNumbered:=True, Name:="TrialName")
Set objB = ActiveDocument.ListTemplates(Index:="TrialName")
Debug.Print objB.Name
```