### PR TITLE
Disambiguate between Class Properties and Document Properties

### DIFF
--- a/Library-Reference-VBA/articles/80738562-8b0b-33f1-3dfa-0d66b1844ef7.md
+++ b/Library-Reference-VBA/articles/80738562-8b0b-33f1-3dfa-0d66b1844ef7.md
@@ -17,11 +17,11 @@ Creates a new custom document property. You can add a new document property only
 
 |**Name**|**Required/Optional**|**Data Type**|**Description**|
 |:-----|:-----|:-----|:-----|
-| _Name_|Required|**String**|The string of the [Name](http://msdn.microsoft.com/library/b609c38e-71ca-e019-9852-fc7811dc798f.md%28Office.15%29.aspx) of the property.|
-| _LinkToContent_|Required|**Boolean**|Specifies whether the [LinkToContent](http://msdn.microsoft.com/library/062df6df-cdee-81fc-3244-e229dacaa64e.md%28Office.15%29.aspx) property is linked to the contents of the container document. If this argument is **True**, the _LinkSource_ argument is required; if it's **False**, the value argument is required.|
-| _Type_|Optional|**Variant**|The data type of the of the [Type](a6a18498-7a71-b2fb-f037-195bddd70573.md) property. Can be one of the following **MsoDocProperties** constants: **msoPropertyTypeBoolean**, **msoPropertyTypeDate**, **msoPropertyTypeFloat**, **msoPropertyTypeNumber**, or **msoPropertyTypeString**.|
-| _Value_|Optional|**Variant**|The data value of the [Value](2d66f8f7-0dfd-e3df-168f-1ca0dfbb0e70.md) property, if it's not linked to the contents of the container document. The value is converted to match the data type specified by the _Type_ argument, and if it can't be converted, an error occurs. If _LinkToContent_ is **True**, the argument is ignored and the new document property is assigned a default value until the linked property values are updated by the container application (usually when the document is saved).|
-| _LinkSource_|Optional|**Variant**|Ignored if  _LinkToContent_ is **False**. The source of the[LinkSource](http://msdn.microsoft.com/library/3e3a6ebc-615a-298e-c40f-cbb6d5cf63e3.md%28Office.15%29.aspx) property. The container application determines what types of source linking you can use. For example, DDE links use the "Server|Document!Item" syntax.|
+| _Name_|Required|**String**|The name of the document property. This will be seen by users in the custom properties window, and will be used by developers to access the custom property.|
+| _LinkToContent_|Required|**Boolean**|Specifies whether the document property is linked to the contents of the container document. If this argument is **True**, the _LinkSource_ argument is required; if it's **False**, the value argument is required.|
+| _Type_|Optional|**Variant**|The type of the document property. Can be one of the following **MsoDocProperties** constants: **msoPropertyTypeBoolean**, **msoPropertyTypeDate**, **msoPropertyTypeFloat**, **msoPropertyTypeNumber**, or **msoPropertyTypeString**.|
+| _Value_|Optional|**Variant**|The value of the document property, if it's not linked to the contents of the container document. The value is converted to match the data type specified by the _Type_ argument, and if it can't be converted, an error occurs. If _LinkToContent_ is **True**, the argument is ignored and the new document property is assigned a default value until the linked property values are updated by the container application (usually when the document is saved).|
+| _LinkSource_|Optional|**Variant**|Ignored if  _LinkToContent_ is **False**. The source of the document property. The container application determines what types of source linking you can use. For example, DDE links use the "Server|Document!Item" syntax.|
 
 ## Remarks
 


### PR DESCRIPTION
Modified the explanations to refer to the actual document property rather than the VBA properties of the DocumentProperty class. It was confusing, and sometimes wrong.

Removed some markdown links. Maybe they could be restored, I don't know how to use them.