### PR TITLE
Update 00630b25-e7b8-5c32-b6d1-9816f01c3a0f.md

### DIFF
--- a/Language-Reference-VBA/articles/00630b25-e7b8-5c32-b6d1-9816f01c3a0f.md
+++ b/Language-Reference-VBA/articles/00630b25-e7b8-5c32-b6d1-9816f01c3a0f.md
@@ -6,7 +6,7 @@
  **Description**
 Returns a zero-based array containing subset of a string array based on a specified filter criteria.
  **Syntax**
- **Filter( _sourcesrray, match_** [ **_, include_** [ **_, compare_** ]] **)**
+ **Filter( _sourcearray, match_** [ **_, include_** [ **_, compare_** ]] **)**
 The  **Filter** function syntax has these[named argument](b8bdf64f-5920-1ae9-16d0-b26d09524a30.md):
 
 


### PR DESCRIPTION
Corrected a single-character error in syntax text:

> source**s**rray

which should be corrected to:

> source**a**rray

That is the only occurrence of that error in this document.

Now I feel like I'm part of something huge, and that feels good :-)