### PR TITLE
Added See also section

### DIFF
--- a/VBA/Language-Reference-VBA/articles/23c9697a-9c6b-18f8-2b86-a0735f082c67.md
+++ b/VBA/Language-Reference-VBA/articles/23c9697a-9c6b-18f8-2b86-a0735f082c67.md
@@ -17,7 +17,7 @@ The  **Err** object's properties are reset to zero or zero-length strings ("") a
 
 Use the  **Raise** method, rather than the **Error** statement, to generate run-time errors for system errors and class modules. Using the **Raise** method in other code depends on the richness of the information you want to return.
 
-The  **Err** object is an intrinsic object with global[scope](b8bdf64f-5920-1ae9-16d0-b26d09524a30.md). There is no need to create an instance of it in your code.
+The  **Err** object is an intrinsic object with global [scope](b8bdf64f-5920-1ae9-16d0-b26d09524a30.md). There is no need to create an instance of it in your code.
 
 
 ## Example
@@ -40,3 +40,13 @@ End If
 
 ```
 
+## See also
+
+#### Concepts
+
+[Handle Run-Time Errors in VBA](../../Access-VBA/articles/a0e06a1e-2709-aa51-92d0-340788a31a8a.md)
+
+#### Other resources
+
+[Raise Method](7e3ddb06-db93-ebce-7562-8a15c49261b1.md)
+[Trappable Errors](11bf80a2-cc16-749f-3b7e-3b08ecf36081.md)


### PR DESCRIPTION
One of the reasons that someone might look at the Err documentation is to understand how they might raise a custom error (that's why I looked it up, anyway). There is no See also section for this article right now, and I think it would benefit from one, even if it had different links than those I am proposing. 

In addition to a minor spacing edit, I'm adding a Concept link to an ariticle on handling VBA runtime errors, as well as two Resource links for a list of trappable errors, and also how to raise your own error. 