### PR TITLE
Update 3ce44cca-9979-0a1e-9787-079a52ce528f.md

### DIFF
--- a/VBA/Access-VBA/articles/3ce44cca-9979-0a1e-9787-079a52ce528f.md
+++ b/VBA/Access-VBA/articles/3ce44cca-9979-0a1e-9787-079a52ce528f.md
@@ -18,9 +18,6 @@ DoCmd.OpenForm "Employees", , ,"[Title] = 'Sales Representative'"
 ```
 
 The  **DoCmd** object doesn't support methods corresponding to the following actions:
-
-
-- AddMenu.
     
 - MsgBox. Use the  **MsgBox** function.
     


### PR DESCRIPTION
Removed AddMenu from the list of methods that DoCmd doesn't support. AddMenu is the first entry listed in DoCmd methods.
