### PR TITLE
Update Description for xlMissingItemsMax2 enum

### DIFF
--- a/VBA/Excel-VBA/articles/3450ac87-7a30-f2dd-efc8-fcd336b26319.md
+++ b/VBA/Excel-VBA/articles/3450ac87-7a30-f2dd-efc8-fcd336b26319.md
@@ -9,5 +9,5 @@ Specifies the maximum number of unique items allowed per PivotField.
 |:-----|:-----|:-----|
 | **xlMissingItemsDefault**|-1|The default number of unique items per PivotField allowed.|
 | **xlMissingItemsMax**|32500|The maximum number of unique items per PivotField allowed (32,500) for a pre-Excel 2007 PivotTable.|
-| **xlMissingItemsMax2**|1048576|The maximum number of unique items per PivotField allowed (10,48,576) for a pre-Excel 2007 PivotTable.|
+| **xlMissingItemsMax2**|1048576|The maximum number of unique items per PivotField allowed (1,048,576) for PivotTables in Excel 2007 and later. 
 | **xlMissingItemsNone**|0|No unique items per PivotField allowed (zero).|


### PR DESCRIPTION
Previously read, "...per PivotField allowed (10,48,576) for a pre-Excel 2007 PivotTable."
Changed to read ",...per PivotField allowed (1,048,576) for PivotTables in Excel 2007 and later."
Unable to find any corroborating documentation so far. The language here seems to have been copied over verbatim from previous documentation, propagating what looks like an error that has appeared in multiple sources online. 
Compare xlMissingItemsMax2 to xlMissingItemsMax.