### PR TITLE
updated description of parameter ID in .ProjectResourceNew

### DIFF
--- a/VBA/Project-VBA/articles/9b030fbc-5cca-df10-f7a3-613d7ad70dc7.md
+++ b/VBA/Project-VBA/articles/9b030fbc-5cca-df10-f7a3-613d7ad70dc7.md
@@ -18,7 +18,7 @@ Occurs before one or more resources is created.
 |**Name**|**Required/Optional**|**Data Type**|**Description**|
 |:-----|:-----|:-----|:-----|
 | _pj_|Required|**Project**|The project in which the resource or resources are being created.|
-| _ID_|Required|**Long**|**False** when the event occurs. If the event procedure sets this argument to **True**, the new resource or resources are not created.|
+| _ID_|Required|**Long**|ID of the new resource in the project.|
 
 ### Return Value
 

--- a/VBA/Project-VBA/articles/9b030fbc-5cca-df10-f7a3-613d7ad70dc7.md
+++ b/VBA/Project-VBA/articles/9b030fbc-5cca-df10-f7a3-613d7ad70dc7.md
@@ -29,5 +29,5 @@ nothing
 
 Project events do not occur when the project is embedded in another document or application.
 
-The  **ProjectBeforeResourceNew** event doesn't occur during resource pool operations, when inserting or removing a subproject, or when changes have been made using a custom form.
+The  **ProjectResourceNew** event doesn't occur during resource pool operations, when inserting or removing a subproject, or when changes have been made using a custom form.
 


### PR DESCRIPTION
description of the paramter ID in in .ProjectResourceNew was wrong (looks like copy&paste from .ProjectBeforeResourceNew). This description should be more precise here.