### PR TITLE
Removes incorrect limitation about passing objects as arguments to macros

### DIFF
--- a/VBA/Excel-VBA/articles/3e0167ab-b101-018f-0f89-ada116b8bb72.md
+++ b/VBA/Excel-VBA/articles/3e0167ab-b101-018f-0f89-ada116b8bb72.md
@@ -29,7 +29,7 @@ Variant
 
 You cannot use named arguments with this method. Arguments must be passed by position.
 
-The  **Run** method returns whatever the called macro returns. Objects passed as arguments to the macro are converted to values (by applying the **Value** property to the object). This means that you cannot pass objects to macros by using the **Run** method.
+The  **Run** method returns whatever the called macro returns.
 
 
 ## See also


### PR DESCRIPTION
It is possible to do so.