### PR TITLE
Fixing names in the parameters table

### DIFF
--- a/VBA/Word-VBA/articles/5899db5b-254c-17ac-4c4b-943a5a5b44cb.md
+++ b/VBA/Word-VBA/articles/5899db5b-254c-17ac-4c4b-943a5a5b44cb.md
@@ -22,8 +22,8 @@ Inserts a cross-reference to a heading, bookmark, footnote, or endnote, or to an
 | _ReferenceItem_|Required| **Variant**|If ReferenceType is  **wdRefTypeBookmark** , this argument specifies a bookmark name. For all other ReferenceType values, this argument specifies the item number or name in the **Reference type** option in the **Cross-reference** dialog box. Use the **GetCrossReferenceItems** method to return a list of item names that can be used with this argument.|
 | _InsertAsHyperlink_|Optional| **Variant**| **True** to insert the cross-reference as a hyperlink to the referenced item.|
 | _IncludePosition_|Optional| **Variant**| **True** to insert "above" or "below," depending on the location of the reference item in relation to the cross-reference.|
-| _IncludePosition_|Optional| **Variant**| **True** to use a separator to separate the numbers from the associated text. (Use only if the ReferenceType parameter is set to **wdRefTypeNumberedItem** and the ReferenceKind parameter is set to **wdNumberFullContext** .)|
-| _IncludePosition_|Optional| **Variant**|Specifies the string to use as a separator if the SeparateNumbers parameter is set to  **True** .|
+| _SeparateNumbers_|Optional| **Variant**| **True** to use a separator to separate the numbers from the associated text. (Use only if the ReferenceType parameter is set to **wdRefTypeNumberedItem** and the ReferenceKind parameter is set to **wdNumberFullContext** .)|
+| _SeparatorString_|Optional| **Variant**|Specifies the string to use as a separator if the SeparateNumbers parameter is set to  **True** .|
 
 ## Remarks
 


### PR DESCRIPTION
IncludePosition was mistakenly listed 3 times instead of the correct names.

The documentation for [Selection.InsertCrossReference](https://msdn.microsoft.com/en-us/library/office/ff193906.aspx) has them correct and this patch matches that.