### PR TITLE
Add more info to last arg ... Excel12XML

### DIFF
--- a/VBA/Access-VBA/articles/76a567c8-5f12-633f-5433-117135dd6ccd.md
+++ b/VBA/Access-VBA/articles/76a567c8-5f12-633f-5433-117135dd6ccd.md
@@ -14,4 +14,4 @@ Used with the [TransferSpreadsheet](0349d8e0-9363-0eda-4efb-a73c9e643823.md) met
 |**acSpreadsheetTypeExcel8**|8|Microsoft Excel 97 format|
 |**acSpreadsheetTypeExcel9**|8|Microsoft Excel 2000 format|
 |**acSpreadsheetTypeExcel12**|9|Microsoft Excel 2010 format|
-|**acSpreadsheetTypeExcel12Xml**|10|Microsoft Excel 2010/2013/2016 XML format|
+|**acSpreadsheetTypeExcel12Xml**|10|Microsoft Excel 2010/2013/2016 XML format (.xlsx, .xlsm, .xlsb)|


### PR DESCRIPTION
When consulting help for this command, a user might expect to need different arguments for .xlsx versus .xlsm.  This minor tweak to the content makes it clear that last argument supaports all 3 file types:  .xlsx, .xlsm, .xlsb