### PR TITLE
Add a "Known Issue" to warn MacOS developers on this method.

### DIFF
--- a/VBA/Excel-VBA/articles/445d74fb-1a9c-bba4-2d53-0ab0caa876da.md
+++ b/VBA/Excel-VBA/articles/445d74fb-1a9c-bba4-2d53-0ab0caa876da.md
@@ -42,6 +42,10 @@ The  **Refresh** method returns **True** if the query is successfully completed 
 
 To see whether the number of fetched rows exceeded the number of available rows on the worksheet, examine the  **[FetchedRowOverflow](386aaf06-27d4-bfa1-cf5e-ac8c8bddef44.md)** property. This property is initialized every time the **Refresh** method is called.
 
+## Known Issues
+
+This method is broken on Excel for Mac. Currently, attempting to run the command in Excel for Mac will result in an unresponsive program, triggering a memory leak which will eat ~1GB/second depending on your hardware speed, eventually resulting in a crash. 
+Your code should be aware of this and work around this command with a platform-dependend conditional if it's run in MacOS. 
 
 ## See also
 


### PR DESCRIPTION
The method is broken on Mac and so far Microsoft has not fixed it. It triggers a runaway memory leakage, freezing the app and eventually crashing it. 

There should be a warning for developers trying to make their code compatible with Excel for Mac to not use this method until the bug is fixed. it is a longstanding issue with no ETA to be fixed.