### PR TITLE
Rewording for clarity.

### DIFF
--- a/VBA/Word-VBA/articles/86add1f8-9c1f-57c0-87d5-9fdef0841880.md
+++ b/VBA/Word-VBA/articles/86add1f8-9c1f-57c0-87d5-9fdef0841880.md
@@ -1,7 +1,7 @@
 
 # Font.Duplicate Property (Word)
 
-Returns a read-only  **Font** object that represents the character formatting of the specified font.
+Returns a stand-alone **Font** object that copies the character formatting of the specified font.
 
 
 ## Syntax
@@ -13,7 +13,7 @@ Returns a read-only  **Font** object that represents the character formatting of
 
 ## Remarks
 
-You can use the  **Duplicate** property to pick up the settings of all the properties of a duplicated **Font** object. You can assign the object returned by the **Duplicate** property to another **Font** object to apply those settings all at once. Before assigning the duplicate object to another object, you can change any of the properties of the duplicate object without affecting the original.
+You can use the  **Duplicate** property to pick up the settings of all the properties of the specified **Font** object. You can assign the object returned by the **Duplicate** property to another **Font** object to apply those settings all at once. Before assigning the duplicate object to another object, you can change any of the properties of the duplicate object without affecting the original.
 
 
 ## Example


### PR DESCRIPTION
This page stated that the property returns a "read-only" font object. This is contradicted by the remarks and by the example. I suggest "stand-alone" instead of "read-only", and  some other wording changes to attempt to make clear the relationship between the specified font and the returned font object.