### PR TITLE
ExpirationDate parameter is unused - updating doc

### DIFF
--- a/VBA/Office-Shared-VBA/articles/9674440f-8b0f-c611-3a02-f0ba1e92be94.md
+++ b/VBA/Office-Shared-VBA/articles/9674440f-8b0f-c611-3a02-f0ba1e92be94.md
@@ -19,7 +19,7 @@ Creates a set of permissions on the active document for the specified user. Retu
 |:-----|:-----|:-----|:-----|
 | _UserID_|Required|**String**|The e-mail address (in the format user@domain.com) of the user to whom permissions on the active document are being granted.|
 | _Permission_|Optional|**msoPermission**|The permissions on the active document that are being granted to the specified user.|
-| _ExpirationDate_|Optional|**Date**|The expiration date for the permissions that are being granted.|
+| _ExpirationDate_|Optional|**Date**|The expiration date for the permissions that are being granted. *Note: this parameter is not used and will be ignored.*|
 
 ## Example
 


### PR DESCRIPTION
We discovered that the ExpirationDate parameter is not actually used by Office. This document is now updated to reflect that.