### PR TITLE
Corrected link.

### DIFF
--- a/VBA/Word-VBA/articles/5f08e24f-6b0c-441d-c067-41b83b4ec1c3.md
+++ b/VBA/Word-VBA/articles/5f08e24f-6b0c-441d-c067-41b83b4ec1c3.md
@@ -13,7 +13,7 @@ Returns or sets the vertical distance between the edge of the rows and the item 
 
 ## Remarks
 
-This property can be a number that indicates a measurement in points, or can be any valid  **[WdFramePosition](ff814d0e-0b15-b8e6-854e-a8f67a7568a1.md)** constant.
+This property can be a number that indicates a measurement in points, or can be any valid  **[WdTablePosition](a14cde7e-a46e-3a04-a178-ec957d1b9869.md)** constant.
 
 
 ## Example


### PR DESCRIPTION
Used to incorrectly link to wdFramePosition enumeration. Now correctly links to wdTablePosition enumeration.