### PR TITLE
Update ddba70e5-8b60-4ce6-631f-fb10f81a6d93.md

### DIFF
--- a/VBA/Language-Reference-VBA/articles/ddba70e5-8b60-4ce6-631f-fb10f81a6d93.md
+++ b/VBA/Language-Reference-VBA/articles/ddba70e5-8b60-4ce6-631f-fb10f81a6d93.md
@@ -13,6 +13,6 @@ The  **DriveExists** method syntax has these parts:
 |**Part**|**Description**|
 |:-----|:-----|
 | _object_|Required. Always the name of a  **FileSystemObject**.|
-| _drivespec_|Required. A drive letter or a complete path specification.|
+| _drivespec_|Required. A drive letter or a path specification for the root of the drive.|
  **Remarks**
 For drives with removable media, the  **DriveExists** method returns **True** even if there are no media present. Use the **IsReady** property of the **Drive** object to determine if a drive is ready.


### PR DESCRIPTION
Previous wording seemed to indicate a path specification such as a file name or non-root folder name could be provided to test if the drive exists. Testing in Excel 2010 VBA indicates this is not so. Results below.
? fso.DriveExists("C:\Temp\Encoding Time.csv")
False
? fso.DriveExists("C:\Temp\")
False
' This folder does exist
? fso.FolderExists("C:\Temp")
True
' However, DriveExists returns false when using this path
? fso.DriveExists("C:\Temp")
False
' Any path specifying the root of the drive does return expected value
? fso.DriveExists("C:\")
True
? fso.DriveExists("C:")
True
? fso.DriveExists("C")
True