### PR TITLE
Fixed ControlType value for Charts

### DIFF
--- a/VBA/Access-VBA/articles/3afa6ed8-db2d-6116-85ce-f1b67990fc1f.md
+++ b/VBA/Access-VBA/articles/3afa6ed8-db2d-6116-85ce-f1b67990fc1f.md
@@ -28,7 +28,8 @@ The  **ControlType** property setting is an intrinsic constant that specifies th
 |**acLabel**|[Label](109ef3a4-9b3d-161c-a11f-ef6aec46d517.md)|
 |**acLine**|[Line](1b3ead4c-84f3-4cbc-7794-8058b2b29dc0.md)|
 |**acListBox**|[List box](279e2f07-9f6d-df03-812c-d232cdeb6fd7.md)|
-|**acObjectFrame**|[Unbound object frame](4a0874dc-ecac-be7c-25e2-ecc79696e2eb.md)or [Chart](05e55ac2-f891-f008-18d8-173c3eed6c7f.md)|
+|**acObjectFrame**|[Unbound object frame](4a0874dc-ecac-be7c-25e2-ecc79696e2eb.md)|
+|**113** (no constant)|[Chart](05e55ac2-f891-f008-18d8-173c3eed6c7f.md)|
 |**acOptionButton**|[Option button](b57e3a3f-450c-65a0-c076-96d9e047c22d.md)|
 |**acOptionGroup**|[Option group](a67b22b7-d3a8-c9c6-cb1b-a6d544b2fefe.md)|
 |**acPage**|[Page](2c67eea5-2f04-807e-f07b-ebcc82dd1a21.md)|


### PR DESCRIPTION
Charts return a ControlType value of 113, not 114 (which would be acObjectFrame). There is currently no ControlType constant for the value 113.