### PR TITLE
Minor fixes

### DIFF
--- a/VBA/Language-Reference-VBA/articles/dir-function.md
+++ b/VBA/Language-Reference-VBA/articles/dir-function.md
@@ -40,7 +40,7 @@ The  _attributes_[argument](vbe-glossary.md) settings are:
  **Note**  These constants are specified by Visual Basic for Applications and can be used anywhere in your code in place of the actual values.
 
  **Remarks**
-In Microsoft Windows,  **Dir** supports the use of multiple character ( ***** ) and single character ( **?** ) wildcards to specify multiple files. On the Macintosh, these characters are treated as valid file name characters and can't be used as wildcards to specify multiple files.
+In Microsoft Windows,  **Dir** supports the use of multiple character ( **\*** ) and single character ( **?** ) wildcards to specify multiple files. On the Macintosh, these characters are treated as valid file name characters and can't be used as wildcards to specify multiple files.
 Since the Macintosh doesn't support the wildcards, use the file type to identify groups of files. You can use the  **MacID** function to specify file type instead of using the file names. For example, the following statement returns the name of the first TEXT file in the current folder:
 
 

--- a/VBA/Language-Reference-VBA/articles/keycode-constants.md
+++ b/VBA/Language-Reference-VBA/articles/keycode-constants.md
@@ -111,7 +111,7 @@ The following constants represent keys on the numeric keypad:
 |**vbKeyNumpad7**|0x67|7 key|
 |**vbKeyNumpad8**|0x68|8 key|
 |**vbKeyNumpad9**|0x69|9 key|
-|**vbKeyMultiply**|0x6A|MULTIPLICATION SIGN ( ***** ) key|
+|**vbKeyMultiply**|0x6A|MULTIPLICATION SIGN ( **\*** ) key|
 |**vbKeyAdd**|0x6B|PLUS SIGN ( **+** ) key|
 |**vbKeySeparator**|0x6C|ENTER key|
 |**vbKeySubtract**|0x6D|MINUS SIGN ( **-** ) key|

--- a/VBA/Language-Reference-VBA/articles/kill-statement.md
+++ b/VBA/Language-Reference-VBA/articles/kill-statement.md
@@ -19,7 +19,7 @@ Deletes files from a disk.
 
 The required  _pathname_[argument](vbe-glossary.md) is a[string expression](vbe-glossary.md) that specifies one or more file names to be deleted. The _pathname_ may include the directory or folder, and the drive.
  **Remarks**
-In Microsoft Windows,  **Kill** supports the use of multiple-character ( ***** ) and single-character ( **?** ) wildcards to specify multiple files. However, on the Macintosh, these characters are treated as valid file name characters and can't be used as wildcards to specify multiple files.
+In Microsoft Windows,  **Kill** supports the use of multiple-character ( **\*** ) and single-character ( **?** ) wildcards to specify multiple files. However, on the Macintosh, these characters are treated as valid file name characters and can't be used as wildcards to specify multiple files.
 Since the Macintosh doesn't support the wildcards, use the file type to identify groups of files to delete. You can use the  **MacID** function to specify file type instead of repeating the command with separate file names. For example, the following statement deletes all TEXT files in the current folder.
 
 

--- a/VBA/Language-Reference-VBA/articles/like-operator.md
+++ b/VBA/Language-Reference-VBA/articles/like-operator.md
@@ -37,13 +37,13 @@ Built-in pattern matching provides a versatile tool for string comparisons. The 
 |**Characters in  _pattern_**|**Matches in  _string_**|
 |:-----|:-----|
 |**?**|Any single character.|
-|*****|Zero or more characters.|
+|**\***|Zero or more characters.|
 |**#**|Any single digit (0-9).|
 |[ _charlist_ ]|Any single character in  _charlist_.|
 |[ **!**_charlist_ ]|Any single character not in  _charlist_.|
 A group of one or more characters ( _charlist_ ) enclosed in brackets ( **[ ]** ) can be used to match any single character in _string_ and can include almost any[character code](vbe-glossary.md), including digits.
 
- **Note**  To match the special characters left bracket ( **[** ), question mark ( **?** ), number sign ( **#** ), and asterisk ( ***** ), enclose them in brackets. The right bracket ( **]** ) can't be used within a group to match itself, but it can be used outside a group as an individual character.
+ **Note**  To match the special characters left bracket ( **[** ), question mark ( **?** ), number sign ( **#** ), and asterisk ( **\*** ), enclose them in brackets. The right bracket ( **]** ) can't be used within a group to match itself, but it can be used outside a group as an individual character.
 
 By using a hyphen ( **-** ) to separate the upper and lower bounds of the range, _charlist_ can specify a range of characters. For example, `[A-Z]` results in a match if the corresponding character position in _string_ contains any uppercase letters in the range A-Z. Multiple ranges are included within the brackets without delimiters.
 The meaning of a specified range depends on the character ordering valid at [run time](vbe-glossary.md) (as determined by **Option Compare** and the[locale](vbe-glossary.md) setting of the system the code is running on). Using the **Option Compare Binary** example, the range `[A-E]` matches A, B and E. With **Option Compare Text**, `[A-E]` matches A, a, À, à, B, b, E, e. The range does not match Ê or ê because accented characters fall after unaccented characters in the sort order.

--- a/VBA/Language-Reference-VBA/articles/like-operator.md
+++ b/VBA/Language-Reference-VBA/articles/like-operator.md
@@ -75,6 +75,11 @@ MyCheck = "a2a" Like "a#a"    ' Returns True.
 MyCheck = "aM5b" Like "a[L-P]#[!c-e]"    ' Returns True.
 MyCheck = "BAT123khg" Like "B?T*"    ' Returns True.
 MyCheck = "CAT123khg" Like "B?T*"    ' Returns False.
+MyCheck = "ab" Like "a*b"    ' Returns True.
+MyCheck = "a*b" Like "a[*]b"    ' Returns True.
+MyCheck = "axxxxxb" Like "a[*]b"    ' Returns False.
+MyCheck = "a[xyz" Like "a[[]*"    ' Returns True.
+MyCheck = "a[xyz" Like "a[*"    ' Throws Error 93 (invalid pattern string).
 ```
 
 

--- a/VBA/Language-Reference-VBA/articles/macid-function.md
+++ b/VBA/Language-Reference-VBA/articles/macid-function.md
@@ -18,7 +18,7 @@ Used on the Macintosh to convert a 4-character [constant](vbe-glossary.md) to a 
  **MacID(** constant **)**
 The required  _constant_ argument consists of 4 characters used to specify a resource type, file type, application signature, or Apple Event, for example, TEXT, OBIN, "XLS5" for Excel files ("XLS8" for Excel 97), Microsoft Word uses "W6BN" ("W8BN" for Word 97), and so on.
  **Remarks**
- **MacID** is used with **Dir** and **Kill** to specify a Macintosh file type. Since the Macintosh does not support ***** and **?** as wildcards, you can use a four-character constant instead to identify groups of files. For example, the following statement returns TEXT type files from the current folder:
+ **MacID** is used with **Dir** and **Kill** to specify a Macintosh file type. Since the Macintosh does not support **\*** and **?** as wildcards, you can use a four-character constant instead to identify groups of files. For example, the following statement returns TEXT type files from the current folder:
 
 
 

--- a/VBA/Language-Reference-VBA/articles/name-statement.md
+++ b/VBA/Language-Reference-VBA/articles/name-statement.md
@@ -26,7 +26,7 @@ The  **Name** statement syntax has these parts:
 | _newpathname_|Required. String expression that specifies the new file name and location — may include directory or folder, and drive. The file name specified by  _newpathname_ can't already exist.|
  **Remarks**
 The Name statement renames a file and moves it to a different directory or folder, if necessary. Name can move a file across drives, but it can only rename an existing directory or folder when both newpathname and oldpathname are located on the same drive. Name cannot create a new file, directory, or folder.
-Using  **Name** on an open file produces an error. You must close an open file before renaming it. **Name**[arguments](vbe-glossary.md) cannot include multiple-character ( ***** ) and single-character ( **?** ) wildcards.
+Using  **Name** on an open file produces an error. You must close an open file before renaming it. **Name**[arguments](vbe-glossary.md) cannot include multiple-character ( **\*** ) and single-character ( **?** ) wildcards.
 
 ## Example
 

--- a/VBA/Language-Reference-VBA/articles/operator.md
+++ b/VBA/Language-Reference-VBA/articles/operator.md
@@ -16,7 +16,7 @@ ms.date: 06/08/2017
 Used to multiply two numbers.
  **Syntax**
  _result_**=**_number1_ * _number2_
-The  ***** operator syntax has these parts:
+The  **\*** operator syntax has these parts:
 
 
 |**Part**|**Description**|
@@ -41,7 +41,7 @@ If one or both expressions are [Null](vbe-glossary.md) expressions, _result_ is 
 
 ## Example
 
-This example uses the  ***** operator to multiply two numbers.
+This example uses the  **\*** operator to multiply two numbers.
 
 
 ```vb


### PR DESCRIPTION
Fixed bold asterisks (`*****` was replaced by `**\***` which will render correctly to **\***).
Added examples to the Like operator page about escaping.