### PR TITLE
Duplicate code

### DIFF
--- a/VBA/Excel-VBA/articles/worksheetfunction-match-method-excel.md
+++ b/VBA/Excel-VBA/articles/worksheetfunction-match-method-excel.md
@@ -113,43 +113,6 @@ Sub HighlightMatches()
           End If
        Next iRow
     Application.ScreenUpdating = True
-End SubSub HighlightMatches()
-
-Application.ScreenUpdating = False
-
-'Declare variables
-Dim var As Variant, iSheet As Integer, iRow As Long, iRowL As Long, bln As Boolean
-   
-   'Set up the count as the number of filled rows in the first column of Sheet1.
-   iRowL = Cells(Rows.Count, 1).End(xlUp).Row
-   
-   'Cycle through all the cells in that column:
-   For iRow = 1 To iRowL
-      'For every cell that is not empty, search through all the columns in all the worksheets in the
-      'workbook for a value that matches that cell value.
-      If Not IsEmpty(Cells(iRow, 1)) Then
-         For iSheet = ActiveSheet.Index + 1 To Worksheets.Count
-            bln = False
-            var = Application.Match(Cells(iRow, 1).Value, Worksheets(iSheet).Columns(1), 0)
-            
-            'If you find a matching value, indicate success by setting bln to true and exit the loop;
-            'otherwise, continue searching until you reach the end of the workbook.
-            If Not IsError(var) Then
-               bln = True
-               Exit For
-            End If
-         Next iSheet
-      End If
-      
-      'If you do not find a matching value, do not bold the value in the original list;
-      'if you do find a value, bold it.
-      If bln = False Then
-         Cells(iRow, 1).Font.Bold = False
-         Else
-         Cells(iRow, 1).Font.Bold = True
-      End If
-   Next iRow
-Application.ScreenUpdating = True
 End Sub
 ```
 


### PR DESCRIPTION
Same subroutine (code wise) was pasted in twice, the only difference between the 2 subs was the one comment. "'For every cell that is not empty, search through **all the columns** in all the worksheets in the.." Should be "'For every cell that is not empty, search through **the first column** in each worksheet in the.."