### PR TITLE
Range.ClearContents removes non-formula values

### DIFF
--- a/VBA/Excel-VBA/articles/range-clearcontents-method-excel.md
+++ b/VBA/Excel-VBA/articles/range-clearcontents-method-excel.md
@@ -13,7 +13,7 @@ ms.date: 06/08/2017
 
 # Range.ClearContents Method (Excel)
 
-Clears the formulas from the range.
+Clears formulas and values from the range.
 
 
 ## Syntax
@@ -30,7 +30,7 @@ Variant
 
 ## Example
 
-This example clears the formulas from cells A1:G37 on Sheet1 but leaves the formatting intact.
+This example clears formulas and values from cells A1:G37 on `Sheet1`, but leaves the cell formatting and conditional formatting intact.
 
 
 ```vb


### PR DESCRIPTION
`Range.ClearContents` removes not only formulas (which I think of as starting with `=`), but also non-formula values.  Change the description to clarify.  Also, clarify that conditional formatting is not removed.