### PR TITLE
ChDir article needs headings and restructuring

### DIFF
--- a/VBA/Language-Reference-VBA/articles/chdir-statement.md
+++ b/VBA/Language-Reference-VBA/articles/chdir-statement.md
@@ -13,23 +13,28 @@ ms.date: 06/08/2017
 
 Changes the current directory or folder.
 
- **Syntax**
 
- **ChDir**_path_
+## Syntax
 
-The required  _path_[argument](vbe-glossary.md) is a[string expression](vbe-glossary.md) that identifies which directory or folder becomes the new default directory or folder. The _path_ may include the drive. If no drive is specified, **ChDir** changes the default directory or folder on the current drive.
- **Remarks**
-The  **ChDir** statement changes the default directory but not the default drive. For example, if the default drive is C, the following statement changes the default directory on drive D, but C remains the default drive:
+**ChDir** _path_
 
+The required  _path_ [argument](vbe-glossary.md) is a [string expression](vbe-glossary.md) that identifies which directory or folder becomes the new default directory or folder. The _path_ may include the drive. If no drive is specified, **ChDir** changes the default directory or folder on the current drive.
+
+
+## Remarks
+
+The  **ChDir** statement changes the default directory or folder but does not change the default drive. A different statement, **[ChDrive](chdrive-statement.md)**, changes the default drive. 
 
 
 ```
-ChDir "D:\TMP" 
+ChDir "D:\TMP" ' Make "D:\TMP" the current folder. 
+
+ChDrive "D"    ' Make "D" the current drive. 
 
 ```
+
 
 On the Power Macintosh, the default drive always changes to the drive specified in  _path_. Full path specifications begin with the volume name, and relative paths begin with a colon ( **:** ). **ChDir** resolves any aliases specified in the path:
-
 
 
 ```
@@ -37,8 +42,8 @@ ChDir "MacDrive:Tmp" ' On the Macintosh.
 
 ```
 
-Note that when making relative directory changes, different symbols are used in Microsoft Windows and on the Macintosh:
 
+Note that when making relative directory changes, different symbols are used in Microsoft Windows and on the Macintosh:
 
 
 ```
@@ -47,19 +52,32 @@ ChDir "::" ' Moves up one directory on the Macintosh.
 ```
 
 
+On the Macintosh, the default drive name is "HD" and portions of the pathname are separated by colons instead of backslashes. Similarly, you would specify Macintosh folders instead of Windows. Finally, wildcard characters have no special meaning on the Macintosh and are treated simply as characters.
+
+
 ## Example
 
-This example uses the  **ChDir** statement to change the current directory or folder. On the Macintosh, the default drive name is "HD" and portions of the pathname are separated by colons instead of backslashes. Similarly, you would specify Macintosh folders instead of \Windows. Finally, wildcard characters have no special meaning on the Macintosh and are treated simply as characters.
+This example uses the  **ChDir** statement to change the current directory or folder. If the default drive is C, then default drive remains C, even though the default folder changes to a folder on drive D:
 
-
-```vb
-' Change current directory or folder to "MYDIR". 
-ChDir "MYDIR" 
- 
+```
 ' Assume "C:" is the current drive. The following statement changes 
 ' the default directory on drive "D:". "C:" remains the current drive. 
 ChDir "D:\WINDOWS\SYSTEM" 
 
 ```
 
+
+## See also
+
+
+#### Reference
+
+
+[ChDrive](chdrive-statement.md)
+
+[CurDir](curdir-statement.md)
+
+[MkDir](mkdir-statement.md)
+
+[RmDir](rmdir-statement.md)
 


### PR DESCRIPTION
I marked Syntax and Remarks as headings. I moved the Mac info from Example to Remarks. I deleted some redundancy in the Remarks and Example. I added cross-references to other directory statements.