### PR TITLE
Clarify deprecation of MacScript

### DIFF
--- a/VBA/Office-Mac-VBA/AppleScriptTask.md
+++ b/VBA/Office-Mac-VBA/AppleScriptTask.md
@@ -44,4 +44,4 @@ The following is an example of a handler.
 ```
 
 ##What happened to MacScript?
-The **MacScript** command that supports inline AppleScripts in Office for Mac 2011 is deprecated. Due to sandbox restrictions, the **MacScript** command cannot invoke other applications, such as Finder, in Office 2016 for Mac. We recommend that you use the **AppleScriptTask** command instead of the **MacScript** command in apps for Office 2016 for Mac. 
+Earlier versions of Office for Mac implemented a command called **MacScript** that supported inline AppleScripts. Although that command still exists in Office 2016 for Mac, **MacScript** is deprecated. Due to sandbox restrictions, the **MacScript** command cannot invoke other applications, such as Finder, in Office 2016 for Mac. We recommend that you use the **AppleScriptTask** command instead of the **MacScript** command in apps for Office 2016 for Mac.


### PR DESCRIPTION
MacScript still exists, but is now deprecated in 2016. The old wording made it sound like MacScript was deprecated in 2011, and that's not true.