### PR TITLE
Update HPageBreak Example

### DIFF
--- a/VBA/Excel-VBA/articles/hpagebreak-object-excel.md
+++ b/VBA/Excel-VBA/articles/hpagebreak-object-excel.md
@@ -30,7 +30,7 @@ Use  **[HPageBreaks](worksheets-hpagebreaks-property-excel.md)** ( _index_ ), wh
 
 
 ```vb
-Worksheets(1).HPageBreaks(1).Location = Worksheets(1).Range("e5")
+Set Worksheets(1).HPageBreaks(1).Location = Worksheets(1).Range("e5")
 ```
 
 


### PR DESCRIPTION
The example provided on the MSDN page is missing the set keyword. Without it, the range at the HPageBreak location has its value changed to the value in the new target range.