### PR TITLE
Clarify a bug with Dir on Excel for Mac 2016.

### DIFF
--- a/VBA/Language-Reference-VBA/articles/dir-function.md
+++ b/VBA/Language-Reference-VBA/articles/dir-function.md
@@ -64,6 +64,7 @@ If you use the  **MacID** function with **Dir** in Microsoft Windows, an error o
 Any  _attribute_ value greater than 256 is considered a **MacID** value.
 You must specify  _pathname_ the first time you call the **Dir** function, or an error occurs. If you also specify file attributes, _pathname_ must be included.
  **Dir** returns the first file name that matches _pathname_. To get any additional file names that match _pathname_, call **Dir** again with no arguments. When no more file names match, **Dir** returns a zero-length string (""). Once a zero-length string is returned, you must specify _pathname_ in subsequent calls or an error occurs. You can change to a new _pathname_ without retrieving all of the file names that match the current _pathname_. However, you can't call the **Dir** function recursively. Calling **Dir** with the **vbDirectory** attribute does not continually return subdirectories.
+With Excel for Mac 2016, the initial **Dir** function call will succeed. Subsequent calls to iterate through the specified directory will cause an error however. This is a known bug unfortunately.
 
  **Tip**  Because file names are retrieved in no particular order, you may want to store returned file names in an [array](vbe-glossary.md), and then sort the array.
 


### PR DESCRIPTION
There appears to be a bug (which presumably is related to MacOS's sandboxing[0])
which causes Dir to fail on Excel for Mac 2016. A number of people appear to
have run into the issue[1,2,3].

Some frustration can perhaps be mitigated by clarifying in the documentation that 
this is known-broken.

The bug can be reproduced with:
```
Sub ListDirectoryContents()
  Dim filename As String
  filename = Dir("/Users/[username]/Library/Group Containers/UBF8T346G9.Office/")

  Do While Len(filename) > 0
    Debug.Print "filename: " & filename
    filename = Dir
  Loop
End Sub
```
(If it's helpful I'm on macOD High Sierra 10.13.2.)

0. https://social.msdn.microsoft.com/Forums/office/en-US/4ff326f1-dd2e-4abc-9746-1c56d8115222/office-2016-vba-it-is-supported-pc-mac-?forum=officegeneral
1. https://stackoverflow.com/questions/44784364/dir-in-excel-for-mac-2016-causes-crash
2. https://stackoverflow.com/questions/38465450/how-to-loop-through-files-in-a-folder-excel-mac-2016
3. https://stackoverflow.com/questions/44784364/dir-in-excel-for-mac-2016-causes-crash/45486880#45486880