### PR TITLE
Delete restriction on number of ConditionalFormats

### DIFF
--- a/VBA/Excel-VBA/articles/formatconditions-add-method-excel.md
+++ b/VBA/Excel-VBA/articles/formatconditions-add-method-excel.md
@@ -41,7 +41,7 @@ A  **[FormatCondition](formatcondition-object-excel.md)** object that represents
 
 ## Remarks
 
-You cannot define more than three conditional formats for a range. Use the  **[Modify](formatcondition-modify-method-excel.md)** method to modify an existing conditional format, or use the **[Delete](formatcondition-delete-method-excel.md)** method to delete an existing format before adding a new one.
+Use the  **[Modify](formatcondition-modify-method-excel.md)** method to modify an existing conditional format, or use the **[Delete](formatcondition-delete-method-excel.md)** method to delete an existing format before adding a new one.
 
 
 ## Example


### PR DESCRIPTION
The restriction on three conditional formats for a range does no longer apply. Time to change the Documentation. (You cannot define more than three conditional formats for a range.)