### PR TITLE
Change description of default value

### DIFF
--- a/VBA/Access-VBA/articles/textbox-locked-property-access.md
+++ b/VBA/Access-VBA/articles/textbox-locked-property-access.md
@@ -25,7 +25,7 @@ The  **Locked** property specifies whether you can edit data in a control in For
 
 ## Remarks
 
-The default setting of the  **Locked** property is **True**. This setting allows editing, adding, and deleting data.
+The default setting of the  **Locked** property is **False**. This setting allows editing, adding, and deleting data.
 
 Use the  **Locked** property to protect data in a field by making it read-only. For example, you might want a control to only display information without allowing editing, or you might want to lock a control until a specific condition is met.
 


### PR DESCRIPTION
(At least in Access 2010) the "Locked" property for form controls means that the control is locked if the property is set to True and unlocked if False. Unless there is some subtlety in the language that I'm missing, all descriptions of "Locked" are reversed. Only when Locked is False can a user edit, add or delete data.

If you agree, the corresponding property descriptions in all other controls needs to be changed.