### PR TITLE
enhanced title + added missing spaces

### DIFF
--- a/VBA/Language-Reference-VBA/articles/goto-statement.md
+++ b/VBA/Language-Reference-VBA/articles/goto-statement.md
@@ -16,11 +16,12 @@ Branches unconditionally to a specified line within a [procedure](vbe-glossary.m
  **GoTo** _line_
 
 The required  _line_ [argument](vbe-glossary.md) can be any [line label](vbe-glossary.md) or [line number](vbe-glossary.md).
+
  **Remarks**
+ 
  **GoTo** can branch only to lines within the procedure where it appears.
 
  **Note**  Too many  **GoTo** statements can make code difficult to read and debug. Use structured control [statements](vbe-glossary.md) ( **Do...Loop**, **For...Next**, **If...Then...Else**, **Select Case** ) whenever possible.
-
 
 ## Example
 

--- a/VBA/Language-Reference-VBA/articles/goto-statement.md
+++ b/VBA/Language-Reference-VBA/articles/goto-statement.md
@@ -1,5 +1,5 @@
 ---
-title: GoTo Statement
+title: GoTo Statement - VBA
 keywords: vblr6.chm1008935
 f1_keywords:
 - vblr6.chm1008935
@@ -7,21 +7,19 @@ ms.prod: office
 ms.assetid: 0fa45435-77cf-91f5-ade4-86ac0eb1a083
 ms.date: 06/08/2017
 ---
-
-
 # GoTo Statement
 
 Branches unconditionally to a specified line within a [procedure](vbe-glossary.md).
 
  **Syntax**
 
- **GoTo**_line_
+ **GoTo** _line_
 
-The required  _line_[argument](vbe-glossary.md) can be any[line label](vbe-glossary.md) or[line number](vbe-glossary.md).
+The required  _line_ [argument](vbe-glossary.md) can be any [line label](vbe-glossary.md) or [line number](vbe-glossary.md).
  **Remarks**
  **GoTo** can branch only to lines within the procedure where it appears.
 
- **Note**  Too many  **GoTo** statements can make code difficult to read and debug. Use structured control[statements](vbe-glossary.md) ( **Do...Loop**, **For...Next**, **If...Then...Else**, **Select Case** ) whenever possible.
+ **Note**  Too many  **GoTo** statements can make code difficult to read and debug. Use structured control [statements](vbe-glossary.md) ( **Do...Loop**, **For...Next**, **If...Then...Else**, **Select Case** ) whenever possible.
 
 
 ## Example
@@ -47,5 +45,3 @@ LastLine:
  ' the Immediate window. 
 End Sub
 ```
-
-


### PR DESCRIPTION
Top search keywords for the Visual Basic topic about GoTo Statement indicates that people are actually searching for VBA Goto not VB. Adding VBA keyword to the title plus adding a few missing spaces throughout the text. We'll do a similar thing on our side as well so topics can be properly ranked.