### PR TITLE
Update worksheet-autofilter-property-excel.md

### DIFF
--- a/VBA/Excel-VBA/articles/worksheet-autofilter-property-excel.md
+++ b/VBA/Excel-VBA/articles/worksheet-autofilter-property-excel.md
@@ -39,7 +39,7 @@ The following example returns autofilter for the current worksheet.
 Dim Worksheet1 As Worksheet 
  
 Dim returnValue As AutoFilter 
-returnValue = Worksheet1.AutoFilter
+Set returnValue = Worksheet1.AutoFilter
 ```
 
 


### PR DESCRIPTION
Objects require the `Set` keyword, otherwise you get RTE91 `Object variable or With block variable not set` .