### PR TITLE
Update Index Data Type from Variant to Integer for Excel.WorkSheet.CustomProperties.Item(Index) method

### DIFF
--- a/VBA/Excel-VBA/articles/customproperties-item-property-excel.md
+++ b/VBA/Excel-VBA/articles/customproperties-item-property-excel.md
@@ -29,7 +29,7 @@ Returns a single object from a collection.
 
 |**Name**|**Required/Optional**|**Data Type**|**Description**|
 |:-----|:-----|:-----|:-----|
-| _Index_|Required| **Variant**|The name or index number of the object.|
+| _Index_|Required| **Integer**|The index number of the object.|
 
 ## Example
 


### PR DESCRIPTION
The CustomProperties collection was not implemented with the CustomProperty.Name indexed.  Entering the name (e.g. as String) of a property throws an error. The documentation is currently inaccurate in stating that you can enter the property name.