### PR TITLE
Update opentextfile-method.md: reference ForWriting

### DIFF
--- a/VBA/Language-Reference-VBA/articles/opentextfile-method.md
+++ b/VBA/Language-Reference-VBA/articles/opentextfile-method.md
@@ -31,15 +31,13 @@ The  **OpenTextFile** method has these parts:
 | _format_|Optional. One of three  **Tristate** values used to indicate the format of the opened file. If omitted, the file is opened as ASCII.|
 
 ## Settings
-The  _iomode_ argument can have either of the following settings:
+The  _iomode_ argument can have any of the following settings:
 
 |**Constant**|**Value**|**Description**|
 |:-----|:-----|:-----|
 |**ForReading**|1|Open a file for reading only. You can't write to this file.|
 |**ForWriting**|2|Open a file for writing only. Use this mode to replace an existing file with new data. You can't read from this file.|
 |**ForAppending**|8|Open a file and write to the end of the file. You can't read from this file.|
-The  _format_ argument can have any of the following settings:
-
 
 The  _format_ argument can have any of the following settings:
 

--- a/VBA/Language-Reference-VBA/articles/opentextfile-method.md
+++ b/VBA/Language-Reference-VBA/articles/opentextfile-method.md
@@ -16,7 +16,7 @@ ms.date: 06/08/2017
 
 
  **Description**
-Opens a specified file and returns a  **TextStream** object that can be used to read from or append to the file.
+Opens a specified file and returns a  **TextStream** object that can be used to read from, write to, or append to the file.
  **Syntax**
  _object_. **OpenTextFile(**_filename_ [ **,**_iomode_ [ **,**_create_ [ **,**_format_ ]]] **)**
 The  **OpenTextFile** method has these parts:
@@ -26,7 +26,7 @@ The  **OpenTextFile** method has these parts:
 |:-----|:-----|
 | _object_|Required. Always the name of a  **FileSystemObject**.|
 | _filename_|Required. [String expression](vbe-glossary.md) that identifies the file to open.|
-| _iomode_|Optional. Indicates input/output mode. Can be one of two constants, either  **ForReading** or **ForAppending**.|
+| _iomode_|Optional. Indicates input/output mode. Can be one of three constants: **ForReading**, **ForWriting**, or **ForAppending**.|
 | _create_|Optional.  **Boolean** value that indicates whether a new file can be created if the specified _filename_ doesn't exist. The value is **True** if a new file is created; **False** if it isn't created. The default is **False**.|
 | _format_|Optional. One of three  **Tristate** values used to indicate the format of the opened file. If omitted, the file is opened as ASCII.|
  **Settings**
@@ -36,7 +36,8 @@ The  _iomode_ argument can have either of the following settings:
 |**Constant**|**Value**|**Description**|
 |:-----|:-----|:-----|
 |**ForReading**|1|Open a file for reading only. You can't write to this file.|
-|**ForAppending**|8|Open a file and write to the end of the file.|
+|**ForWriting**|2|Open a file for writing only. You can't read from this file.|
+|**ForAppending**|8|Open a file and write to the end of the file. You can't read from this file.|
 The  _format_ argument can have any of the following settings:
 
 


### PR DESCRIPTION
Add references to the ForWriting constant, which was missing for unknown reasons. The code sample at the bottom of the page lists ForWriting, but the summary and table did not. (First noted in issue #549.)