### PR TITLE
Change parameter from Optional to Required

### DIFF
--- a/VBA/Excel-VBA/articles/workbook-savecopyas-method-excel.md
+++ b/VBA/Excel-VBA/articles/workbook-savecopyas-method-excel.md
@@ -29,7 +29,7 @@ Saves a copy of the workbook to a file but doesn't modify the open workbook in m
 
 |**Name**|**Required/Optional**|**Data Type**|**Description**|
 |:-----|:-----|:-----|:-----|
-| _Filename_|Optional| **Variant**|Specifies the file name for the copy.|
+| _Filename_|Required| **Variant**|Specifies the file name for the copy.|
 
 ## Example
 


### PR DESCRIPTION
The _Filename_ parameter is not optional (which is logical).  

Attempting to use the method without a parameter (like `Thisworkbook.SaveCopyAs`) produces error:  
`Run-time error 1004: Method 'SaveCopyAs' of object '_Workbook' failed.`