### PR TITLE
Added spaces before links

### DIFF
--- a/VBA/Language-Reference-VBA/articles/resume-statement.md
+++ b/VBA/Language-Reference-VBA/articles/resume-statement.md
@@ -18,15 +18,16 @@ Resumes execution after an error-handling routine is finished.
  **Resume** [ **0** ]
 
  **Resume** **Next**
- **Resume**_line_
+ **Resume** _line_
+ 
 The  **Resume** statement syntax can have any of the following forms:
 
 
 |**Statement**|**Description**|
 |:-----|:-----|
-|**Resume**|If the error occurred in the same [procedure](vbe-glossary.md) as the error handler, execution resumes with the statement that caused the error. If the error occurred in a called procedure, execution resumes at the[statement](vbe-glossary.md) that last called out of the procedure containing the error-handling routine.|
+|**Resume**|If the error occurred in the same [procedure](vbe-glossary.md) as the error handler, execution resumes with the statement that caused the error. If the error occurred in a called procedure, execution resumes at the [statement](vbe-glossary.md) that last called out of the procedure containing the error-handling routine.|
 |**Resume** **Next**|If the error occurred in the same procedure as the error handler, execution resumes with the statement immediately following the statement that caused the error. If the error occurred in a called procedure, execution resumes with the statement immediately following the statement that last called out of the procedure containing the error-handling routine (or  **On Error Resume Next** statement).|
-|**Resume**_line_|Execution resumes at  _line_ specified in the required _line_[argument](vbe-glossary.md). The  _line_ argument is a[line label](vbe-glossary.md) or[line number](vbe-glossary.md) and must be in the same procedure as the error handler.|
+|**Resume**_line_|Execution resumes at  _line_ specified in the required _line_ [argument](vbe-glossary.md). The  _line_ argument is a [line label](vbe-glossary.md) or [line number](vbe-glossary.md) and must be in the same procedure as the error handler.|
  **Remarks**
 If you use a  **Resume** statement anywhere except in an error-handling routine, an error occurs.
 


### PR DESCRIPTION
Added spaces before links - this is an issue in almost all of the VBA documentation. Looks like when it was converted, links lost the preceding space.
Same issue with italics under syntax - it is missing a space in almost all the documentation.

Is there anyway you could run a quick regex replace on everything?
/[^\s]\[/\ \[/
Would work for links.