### PR TITLE
adding VBA to the title

### DIFF
--- a/VBA/Language-Reference-VBA/articles/operators.md
+++ b/VBA/Language-Reference-VBA/articles/operators.md
@@ -1,12 +1,12 @@
 ---
-title: Operators
+title: VBA Operators
 ms.prod: office
 ms.assetid: 6b2abc26-ad22-4b28-9a2b-d178d32538ed
 ms.date: 06/08/2017
 ---
 
 
-# Operators
+# VBA Operators
 
 ## In this section
 


### PR DESCRIPTION
trying to improve SEO for the operators page since we're getting doc issues about VBA operators in our docset