### PR TITLE
Changed filter value to demonstrate its format

### DIFF
--- a/VBA/Access-VBA/articles/specify-date-and-time-in-criteria-expressions.md
+++ b/VBA/Access-VBA/articles/specify-date-and-time-in-criteria-expressions.md
@@ -14,13 +14,13 @@ To specify date or time criteria for an operation, you supply a date or time val
  **Note**  The number signs indicate to Access that the  _criteria_ argument contains a date or time within a string.
 
 
-Suppose that you are creating a filter for an Employees form to display records for all employees born on or after January 1, 1960. You could construct the  _criteria_ argument for the form's **[Filter](form-filter-property-access.md)** or **[ServerFilter](form-serverfilter-property-access.md)** property, as shown in the following example. Note the placement of the number signs.
+Suppose that you are creating a filter for an Employees form to display records for all employees born on or after October 1, 1960. You could construct the  _criteria_ argument for the form's **[Filter](form-filter-property-access.md)** or **[ServerFilter](form-serverfilter-property-access.md)** property, as shown in the following example. Note the format of the string expression - including the number signs - for the date to filter on.
 
 
 
 
 ```vb
-Forms!Employees.Filter = "[BirthDate] >= #1-1-1960#"
+Forms!Employees.Filter = "[BirthDate] >= #10/1/1960#"
 ```
 
 


### PR DESCRIPTION
If month and day have the same value, the format of the filter string cannot be read. Thus, changed month to October.
Also, even though a dash is accepted, changed the date separator to a slash, the default of Access SQL.